### PR TITLE
Upload workspace to bucket upon completion

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,11 @@ jobs:
       - name: List conda environment
         run: micromamba list
 
+      - uses: 'google-github-actions/auth@v3'
+        with:
+          service_account: 'invest-compute-wksp-uploader@natcap-servers.iam.gserviceaccount.com'
+          workload_identity_provider: 'projects/1098785064656/locations/global/workloadIdentityPools/github-actions-invest-compute/providers/invest-compute'
+
       - name: Install package
         run: cd invest_processes && pip install .
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,4 +77,4 @@ jobs:
           export PYGEOAPI_CONFIG=pygeoapi-config.yml
           export PYGEOAPI_OPENAPI=openapi.yml
           pygeoapi openapi generate $PYGEOAPI_CONFIG --output-file $PYGEOAPI_OPENAPI
-          pytest -s -k Error tests/
+          pytest --log-cli-level=DEBUG tests/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,4 +77,4 @@ jobs:
           export PYGEOAPI_CONFIG=pygeoapi-config.yml
           export PYGEOAPI_OPENAPI=openapi.yml
           pygeoapi openapi generate $PYGEOAPI_CONFIG --output-file $PYGEOAPI_OPENAPI
-          pytest tests/
+          pytest -s tests/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,10 @@ jobs:
         ports:
           - "8888:3306"
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+    # For gcp auth, add "id-token" with the intended permissions.
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,4 +77,4 @@ jobs:
           export PYGEOAPI_CONFIG=pygeoapi-config.yml
           export PYGEOAPI_OPENAPI=openapi.yml
           pygeoapi openapi generate $PYGEOAPI_CONFIG --output-file $PYGEOAPI_OPENAPI
-          pytest -s tests/
+          pytest -s -k Error tests/

--- a/invest_processes/pyproject.toml
+++ b/invest_processes/pyproject.toml
@@ -11,7 +11,8 @@ dynamic = ["version"] # the version is provided dynamically by setuptools_scm
 dependencies = [
     "flask",
     "natcap.invest",
-    "pygeoapi"
+    "pygeoapi",
+    "google-cloud-storage"
 ]
 
 [project.urls]

--- a/invest_processes/src/invest_processes/slurm_manager.py
+++ b/invest_processes/src/invest_processes/slurm_manager.py
@@ -285,10 +285,10 @@ class SlurmManager(BaseManager):
         try:
             job_id, workspace_dir = self.submit_slurm_job(processor, data_dict)
         except Exception as ex:
-            LOGGER.error(
+            LOGGER.error((
                 'Something went wrong while trying to submit the slurm job '.
                 'We do not have a job id or workspace yet, so there is nothing to '
-                'return to the user.')
+                'return to the user.'))
             raise ex
 
         try:

--- a/invest_processes/src/invest_processes/slurm_manager.py
+++ b/invest_processes/src/invest_processes/slurm_manager.py
@@ -39,9 +39,9 @@ def upload_directory_to_bucket(dir_path, bucket_name):
     storage_client = storage.Client()
     bucket = storage_client.bucket(bucket_name)
 
-    # get just the directory name, the last component of the path
-    dir_name = os.path.basename(os.path.normpath(dir_path))
-    print(dir_name)
+    # get the parent directory of dir_path
+    parent_dir = os.path.split(os.path.normpath(dir_path))[0]
+    print(parent_dir)
 
     for sub_dir, _, file_names in os.walk(dir_path):
         for file_name in file_names:
@@ -49,8 +49,8 @@ def upload_directory_to_bucket(dir_path, bucket_name):
             abs_path = os.path.join(sub_dir, file_name)
             print(abs_path)
 
-            # relative path starting from dir_name
-            rel_path = os.path.relpath(abs_path, start=dir_path)
+            # relative path starting from the given directory
+            rel_path = os.path.relpath(abs_path, start=parent_dir)
             print(rel_path)
 
             blob = bucket.blob(rel_path)

--- a/invest_processes/src/invest_processes/slurm_manager.py
+++ b/invest_processes/src/invest_processes/slurm_manager.py
@@ -311,6 +311,7 @@ class SlurmManager(BaseManager):
             exit_code = int(subprocess.run([
                 'sacct', '--noheader', '-X', '-j', job_id, '-o', 'ExitCode'
             ], capture_output=True, text=True, check=True).stdout.strip().split(':')[0])
+            print(exit_code)
             LOGGER.debug(f'Exit code of slurm job {job_id}: {exit_code}')
 
             if exit_code != 0:
@@ -329,6 +330,8 @@ class SlurmManager(BaseManager):
             # endpoint, even if the /result endpoint correctly returns the
             # failure information (i.e. what one might assume is a 200
             # response).
+            #
+            print('exception', err)
 
             current_status = JobStatus.failed
             code = 'InvalidParameterValue'
@@ -341,6 +344,7 @@ class SlurmManager(BaseManager):
             LOGGER.exception(err)
 
         finally:
+            print('upload')
             # Upload the workspace even if something went wrong, so that the
             # user can access the slurm related files and any partial results.
             LOGGER.debug(f'Copying workspace for job {job_id} to bucket')

--- a/invest_processes/src/invest_processes/slurm_manager.py
+++ b/invest_processes/src/invest_processes/slurm_manager.py
@@ -274,7 +274,6 @@ class SlurmManager(BaseManager):
 
         :returns: tuple of MIME type, response payload and status
         """
-        print('execute handler sync')
         extra_execute_parameters = {}
 
         # only pass requested_outputs if supported,
@@ -284,7 +283,6 @@ class SlurmManager(BaseManager):
 
         try:
             job_id, workspace_dir = self.submit_slurm_job(processor, data_dict)
-            print(job_id, workspace_dir)
         except Exception as ex:
             LOGGER.error(
                 'Something went wrong while trying to submit the slurm job. '
@@ -304,8 +302,7 @@ class SlurmManager(BaseManager):
                 ], capture_output=True, text=True, check=True).stdout.strip()
                 LOGGER.debug(f'Status of slurm job {job_id}: {status}')
 
-                print('status:', status)
-
+                # TODO: make this more resilient to other possible job states
                 if status == 'COMPLETED' or status == 'FAILED':
                     break
                 time.sleep(1)
@@ -314,7 +311,6 @@ class SlurmManager(BaseManager):
             exit_code = int(subprocess.run([
                 'sacct', '--noheader', '-X', '-j', job_id, '-o', 'ExitCode'
             ], capture_output=True, text=True, check=True).stdout.strip().split(':')[0])
-            print(exit_code)
             LOGGER.debug(f'Exit code of slurm job {job_id}: {exit_code}')
 
             if exit_code != 0:
@@ -333,9 +329,6 @@ class SlurmManager(BaseManager):
             # endpoint, even if the /result endpoint correctly returns the
             # failure information (i.e. what one might assume is a 200
             # response).
-            #
-            print('exception', err)
-
             current_status = JobStatus.failed
             code = 'InvalidParameterValue'
             outputs = {
@@ -347,7 +340,6 @@ class SlurmManager(BaseManager):
             LOGGER.exception(err)
 
         finally:
-            print('upload')
             # Upload the workspace even if something went wrong, so that the
             # user can access the slurm related files and any partial results.
             LOGGER.debug(f'Copying workspace for job {job_id} to bucket')
@@ -370,7 +362,6 @@ class SlurmManager(BaseManager):
         Returns:
             job_id, workspace_dir
         """
-        print('submit slurm job')
         # Create a workspace directory for the slurm job
         # This will contain the slurm script, stdout and stderr logs,
         # and the process being run may create additional outputs in it.
@@ -391,7 +382,6 @@ class SlurmManager(BaseManager):
 
         # Submit the job
         try:
-            print('submit job')
             args = [
                 'sbatch', '--parsable',
                 '--chdir', workspace_dir,
@@ -405,7 +395,6 @@ class SlurmManager(BaseManager):
             LOGGER.info(f'stdout from sbatch: {result.stdout}')
 
         except subprocess.CalledProcessError as e:
-            print(e)
             raise RuntimeError('Error when submitting slurm job') from e
 
         job_id = result.stdout.strip()

--- a/invest_processes/src/invest_processes/slurm_manager.py
+++ b/invest_processes/src/invest_processes/slurm_manager.py
@@ -274,7 +274,7 @@ class SlurmManager(BaseManager):
 
         :returns: tuple of MIME type, response payload and status
         """
-
+        print('execute handler sync')
         extra_execute_parameters = {}
 
         # only pass requested_outputs if supported,
@@ -284,6 +284,7 @@ class SlurmManager(BaseManager):
 
         try:
             job_id, workspace_dir = self.submit_slurm_job(processor, data_dict)
+            print(job_id, workspace_dir)
         except Exception as ex:
             LOGGER.error(
                 'Something went wrong while trying to submit the slurm job. '
@@ -302,6 +303,8 @@ class SlurmManager(BaseManager):
                     '-o', 'State'
                 ], capture_output=True, text=True, check=True).stdout.strip()
                 LOGGER.debug(f'Status of slurm job {job_id}: {status}')
+
+                print('status:', status)
 
                 if status == 'COMPLETED':
                     break
@@ -367,6 +370,7 @@ class SlurmManager(BaseManager):
         Returns:
             job_id, workspace_dir
         """
+        print('submit slurm job')
         # Create a workspace directory for the slurm job
         # This will contain the slurm script, stdout and stderr logs,
         # and the process being run may create additional outputs in it.
@@ -387,6 +391,7 @@ class SlurmManager(BaseManager):
 
         # Submit the job
         try:
+            print('submit job')
             args = [
                 'sbatch', '--parsable',
                 '--chdir', workspace_dir,
@@ -400,6 +405,7 @@ class SlurmManager(BaseManager):
             LOGGER.info(f'stdout from sbatch: {result.stdout}')
 
         except subprocess.CalledProcessError as e:
+            print(e)
             raise RuntimeError('Error when submitting slurm job') from e
 
         job_id = result.stdout.strip()

--- a/invest_processes/src/invest_processes/slurm_manager.py
+++ b/invest_processes/src/invest_processes/slurm_manager.py
@@ -306,7 +306,7 @@ class SlurmManager(BaseManager):
 
                 print('status:', status)
 
-                if status == 'COMPLETED':
+                if status == 'COMPLETED' or status == 'FAILED':
                     break
                 time.sleep(1)
 

--- a/invest_processes/src/invest_processes/slurm_manager.py
+++ b/invest_processes/src/invest_processes/slurm_manager.py
@@ -46,6 +46,7 @@ def upload_directory_to_bucket(dir_path, bucket_name):
     for sub_dir, _, file_names in os.walk(dir_path):
         for file_name in file_names:
             # relative path starting from dir_name
+            print(dir_name, sub_dir, file_name)
             rel_path = os.path.join(dir_name, sub_dir, file_name)
             print(rel_path)
             # absolute path including the full path to the directory

--- a/invest_processes/src/invest_processes/slurm_manager.py
+++ b/invest_processes/src/invest_processes/slurm_manager.py
@@ -34,28 +34,23 @@ def upload_directory_to_bucket(dir_path, bucket_name):
     Returns:
         None
     """
-    print(dir_path)
-    print(bucket_name)
     storage_client = storage.Client()
     bucket = storage_client.bucket(bucket_name)
 
     # get the parent directory of dir_path
     parent_dir = os.path.split(os.path.normpath(dir_path))[0]
-    print(parent_dir)
 
     for sub_dir, _, file_names in os.walk(dir_path):
         for file_name in file_names:
             # absolute path including the full path to the directory
             abs_path = os.path.join(sub_dir, file_name)
-            print(abs_path)
 
             # relative path starting from the given directory
             rel_path = os.path.relpath(abs_path, start=parent_dir)
-            print(rel_path)
 
             blob = bucket.blob(rel_path)
             blob.upload_from_filename(abs_path)
-            print(f"Uploaded {abs_path} to gs://{bucket_name}/{rel_path}")
+            LOGGER.debug(f'Uploaded {abs_path} to gs://{bucket_name}/{rel_path}')
 
 
 class SlurmManager(BaseManager):

--- a/invest_processes/src/invest_processes/slurm_manager.py
+++ b/invest_processes/src/invest_processes/slurm_manager.py
@@ -25,19 +25,32 @@ BUCKET_NAME = 'invest-compute-workspaces'
 
 
 def upload_directory_to_bucket(dir_path, bucket_name):
+    """Upload everything in a given directory to a GCP bucket.
 
+    Args:
+        dir_path (str): path to the directory to be uploaded
+        bucket_name (str): GCP bucket name
+
+    Returns:
+        None
+    """
+    print(dir_path)
+    print(bucket_name)
     storage_client = storage.Client()
     bucket = storage_client.bucket(bucket_name)
 
     # get just the directory name, the last component of the path
     dir_name = os.path.basename(os.path.normpath(dir_path))
+    print(dir_name)
 
     for sub_dir, _, file_names in os.walk(dir_path):
         for file_name in file_names:
             # relative path starting from dir_name
             rel_path = os.path.join(dir_name, sub_dir, file_name)
+            print(rel_path)
             # absolute path including the full path to the directory
             abs_path = os.path.join(dir_path, sub_dir, file_name)
+            print(abs_path)
 
             blob = bucket.blob(rel_path)
             blob.upload_from_filename(abs_path)

--- a/invest_processes/src/invest_processes/slurm_manager.py
+++ b/invest_processes/src/invest_processes/slurm_manager.py
@@ -285,10 +285,10 @@ class SlurmManager(BaseManager):
         try:
             job_id, workspace_dir = self.submit_slurm_job(processor, data_dict)
         except Exception as ex:
-            LOGGER.error((
-                'Something went wrong while trying to submit the slurm job '.
+            LOGGER.error(
+                'Something went wrong while trying to submit the slurm job. '
                 'We do not have a job id or workspace yet, so there is nothing to '
-                'return to the user.'))
+                'return to the user.')
             raise ex
 
         try:

--- a/invest_processes/src/invest_processes/slurm_manager.py
+++ b/invest_processes/src/invest_processes/slurm_manager.py
@@ -45,13 +45,13 @@ def upload_directory_to_bucket(dir_path, bucket_name):
 
     for sub_dir, _, file_names in os.walk(dir_path):
         for file_name in file_names:
-            # relative path starting from dir_name
-            print(dir_name, sub_dir, file_name)
-            rel_path = os.path.join(dir_name, sub_dir, file_name)
-            print(rel_path)
             # absolute path including the full path to the directory
-            abs_path = os.path.join(dir_path, sub_dir, file_name)
+            abs_path = os.path.join(sub_dir, file_name)
             print(abs_path)
+
+            # relative path starting from dir_name
+            rel_path = os.path.relpath(abs_path, start=dir_path)
+            print(rel_path)
 
             blob = bucket.blob(rel_path)
             blob.upload_from_filename(abs_path)

--- a/tests/test_data/carbon_error.invs.json
+++ b/tests/test_data/carbon_error.invs.json
@@ -1,0 +1,14 @@
+{
+    "args": {
+        "calc_sequestration": true, 
+        "carbon_pools_path": "carbon_pools_willamette.csv", 
+        "do_valuation": false, 
+        "lulc_bas_path": "lulc_current_willamette.tif", 
+        "lulc_bas_year": "2020", 
+        "lulc_alt_path": "does_not_exist.tif",
+        "lulc_alt_year": "2050", 
+        "results_suffix": "willamette"
+    }, 
+    "invest_version": "3.7.0", 
+    "model_name": "natcap.invest.carbon"
+}

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -35,7 +35,6 @@ class PyGeoAPIServerTests(unittest.TestCase):
 
     def testExecuteProcessError(self):
         """Test executing a datastack that should cause a model error."""
-        print('start test')
         response = self.client.post(f'/processes/execute/execution', json={
             'inputs': {
                 # this datastack includes an invalid raster path
@@ -50,6 +49,11 @@ class PyGeoAPIServerTests(unittest.TestCase):
             set(os.listdir(data['workspace'])),
             {'stdout.log', 'stderr.log', 'script.slurm', 'carbon_workspace'}
         )
+        # expect model error to be captured in stderr.log
+        with open(os.path.join(data['workspace'], 'stderr.log')) as err_log:
+            self.assertIn(
+                'RuntimeError: does_not_exist.tif: No such file or directory',
+                err_log.read())
 
     def testValidateProcessMetadata(self):
         response = self.client.get(f'/processes/validate')

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -35,6 +35,7 @@ class PyGeoAPIServerTests(unittest.TestCase):
 
     def testExecuteProcessError(self):
         """Test executing a datastack that should cause a model error."""
+        print('start test')
         response = self.client.post(f'/processes/execute/execution', json={
             'inputs': {
                 # this datastack includes an invalid raster path


### PR DESCRIPTION
In this PR, we're using the google cloud storage python API to upload the job workspace, including the slurm artifacts as well as the invest model workspace, to a new bucket [`invest-compute-workspaces`](https://console.cloud.google.com/storage/browser/invest-compute-workspaces;tab=objects?forceOnBucketsSortingFiltering=true&project=natcap-servers&prefix=&forceOnObjectsSortingFiltering=false). The workspaces created in the github action do get uploaded there, and I added a lifecycle rule on the bucket to delete objects more than 3 days old.

The github action run authenticates to GCP using [`google-github-actions/auth`](https://github.com/google-github-actions/auth), and I followed their instructions to set up the necessary components on the GCP side.

Also made some improvements to error handling: the workspace upload will happen even if the job errors, and added a test for this behavior caused by an error raised in the invest model execution.
