### PR TITLE
Configure remote state for terraform

### DIFF
--- a/slurm_cluster_config/README.md
+++ b/slurm_cluster_config/README.md
@@ -11,19 +11,26 @@ The following steps assume that the resulting executable exists at `~/cluster-to
 
 From this directory, run:
 ```
-~/cluster-toolkit/gcluster create hpc-slurm.yml --vars project_id=natcap-servers
+~/cluster-toolkit/gcluster create hpc-slurm.yml --vars project_id=sdss-sdss-invest-compute
 ```
 This uses the `hpc-slurm.yml` blueprint to create the `hpc-slurm` deployment folder, which contains the terraform files.
 
 Copy the additional terraform code into that directory:
 ```
 cp server_interface.tf hpc-slurm/primary
+cp providers.tf hpc-slurm/primary  # overwrite the existing providers.tf
+```
+
+You should already be authenticated with `gcloud` in the correct project. You'll also need to make sure the quota project is set correctly:
+```
+gcloud auth application-default set-quota-project sdss-sdss-invest-compute
 ```
 
 To deploy:
 ```
 cd hpc-slurm/primary
-terraform apply
+terraform init
+terraform plan
 ```
 This will create the infrastructure defined in `hpc-slurm` in your GCP project. At this point, all the necessary GCP resources are in place, but we still need to install software and launch the server.
 

--- a/slurm_cluster_config/README.md
+++ b/slurm_cluster_config/README.md
@@ -7,7 +7,7 @@ These steps are meant to be run on your local dev machine.
 
 Install Google Cluster Toolkit following the instructions:
 https://docs.cloud.google.com/cluster-toolkit/docs/setup/configure-environment
-The following steps assume that the resulting executable exists at `~/cluster-toolkit/gcluster`. All the commands below are run on your development machine, it is not necessary to directly run anything on the cluster instances.
+The following steps assume that the resulting executable exists at `~/cluster-toolkit/gcluster`. All the commands below are run on your development machine, it is not necessary to directly run anything on the cluster instances. You should already be authenticated with `gcloud` in the correct project. Terraform will run with your local application default credentials.
 
 From this directory, run:
 ```
@@ -21,16 +21,12 @@ cp server_interface.tf hpc-slurm/primary
 cp providers.tf hpc-slurm/primary  # overwrite the existing providers.tf
 ```
 
-You should already be authenticated with `gcloud` in the correct project. You'll also need to make sure the quota project is set correctly:
-```
-gcloud auth application-default set-quota-project sdss-sdss-invest-compute
-```
-
 To deploy:
 ```
 cd hpc-slurm/primary
 terraform init
 terraform plan
+terraform apply
 ```
 This will create the infrastructure defined in `hpc-slurm` in your GCP project. At this point, all the necessary GCP resources are in place, but we still need to install software and launch the server.
 

--- a/slurm_cluster_config/providers.tf
+++ b/slurm_cluster_config/providers.tf
@@ -1,0 +1,17 @@
+# Explicitly set the billing (quota) project
+# https://github.com/hashicorp/terraform-provider-google/issues/24500
+provider "google" {
+  project = var.project_id
+  region  = var.region
+  zone    = var.zone
+  billing_project       = "sdss-sdss-invest-compute"
+  user_project_override = true
+}
+
+provider "google-beta" {
+  project = var.project_id
+  region  = var.region
+  zone    = var.zone
+  billing_project       = "sdss-sdss-invest-compute"
+  user_project_override = true
+}

--- a/slurm_cluster_config/server_interface.tf
+++ b/slurm_cluster_config/server_interface.tf
@@ -1,3 +1,10 @@
+# Configure remote state
+terraform {
+  backend "gcs" {
+    bucket  = "invest_compute_terraform_state"
+  }
+}
+
 # Enable the necessary APIs ---------------------------------------------------
 resource "google_project_service" "enable_services" {
   project = var.project_id


### PR DESCRIPTION
Fixes #10 

This PR configures terraform to read state data from a GCS bucket rather than a local file. I created a bucket called `invest_compute_terraform_state` for this purpose. The bucket itself is not defined in terraform because that would create a chicken-and-egg problem. I confirmed that I can now set up another terraform working directory and it will read the remote state and recognize the existing infrastructure. This will be critical for having multiple developers collaborate on the project.