### PR TITLE
Handle multiple API keys for different clients

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -137,12 +137,8 @@ jobs:
         with:
           environment-name: env
           # pin numpy: https://github.com/natcap/invest/issues/2288
-          # requiring python 3.12 because pygeoapi requires rasterio==1.3.9,
-          # which will fail to build from source because it still uses pkg_resources
-          # and does not include the necessary setuptools pin in its metadata.
-          # rasterio 1.3.9 wheels are not available for python>=3.13.
           create-args: >-
-            python=3.12
+            python=3.13
             natcap.invest
             pytest
             numpy<2.4.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -137,14 +137,15 @@ jobs:
         with:
           environment-name: env
           # pin numpy: https://github.com/natcap/invest/issues/2288
-          # setuptools<81 because pkg_resources was deprecated, but
-          # rasterio (dependency of pygeoapi) still needs it
+          # requiring python 3.12 because pygeoapi requires rasterio==1.3.9,
+          # which will fail to build from source because it still uses pkg_resources
+          # and does not include the necessary setuptools pin in its metadata.
+          # rasterio 1.3.9 wheels are not available for python>=3.13.
           create-args: >-
-            python=3.13
+            python=3.12
             natcap.invest
             pytest
             numpy<2.4.0
-            setuptools<81
           condarc: |
             channels:
               - conda-forge

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -137,11 +137,14 @@ jobs:
         with:
           environment-name: env
           # pin numpy: https://github.com/natcap/invest/issues/2288
+          # setuptools<81 because pkg_resources was deprecated, but
+          # rasterio (dependency of pygeoapi) still needs it
           create-args: >-
             python=3.13
             natcap.invest
             pytest
             numpy<2.4.0
+            setuptools<81
           condarc: |
             channels:
               - conda-forge

--- a/invest_processes/pyproject.toml
+++ b/invest_processes/pyproject.toml
@@ -9,12 +9,10 @@ maintainers = [
 ]
 dynamic = ["version"] # the version is provided dynamically by setuptools_scm
 
-# install pygeoapi from their working branch because their releases pin specific
-# versions of each requirement, which are old and conflict with our dependencies
 dependencies = [
     "flask",
     "natcap.invest",
-    "pygeoapi @ git+https://github.com/geopython/pygeoapi.git",
+    "pygeoapi==0.23.0",
     "google-cloud-storage"
 ]
 

--- a/invest_processes/pyproject.toml
+++ b/invest_processes/pyproject.toml
@@ -12,9 +12,6 @@ dependencies = [
     "flask",
     "natcap.invest",
     "pygeoapi>=0.23.2",
-    # rasterio is not a direct dependency, but a dependency of pygeoapi.
-    # older versions need pkg_resources to install, which is deprecated in recent python versions
-    "rasterio>=1.4.0",
     "google-cloud-storage"
 ]
 
@@ -22,7 +19,9 @@ dependencies = [
 homepage = "http://github.com/natcap/invest-compute"
 
 [build-system]
-requires = ['setuptools>=64', 'wheel', 'setuptools_scm>=8.0']
+# setuptools<82 because pkg_resources was deprecated, but we still need it for
+# rasterio as a dependency of pygeoapi
+requires = ['setuptools>=64,<82', 'wheel', 'setuptools_scm>=8.0']
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/invest_processes/pyproject.toml
+++ b/invest_processes/pyproject.toml
@@ -21,7 +21,7 @@ homepage = "http://github.com/natcap/invest-compute"
 [build-system]
 # setuptools<82 because pkg_resources was deprecated, but we still need it for
 # rasterio as a dependency of pygeoapi
-requires = ['setuptools>=64,<82', 'wheel', 'setuptools_scm>=8.0']
+requires = ['setuptools>=64,<81', 'wheel', 'setuptools_scm>=8.0']
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/invest_processes/pyproject.toml
+++ b/invest_processes/pyproject.toml
@@ -8,10 +8,13 @@ maintainers = [
     {name = "Natural Capital Project Software Team"}
 ]
 dynamic = ["version"] # the version is provided dynamically by setuptools_scm
+
+# install pygeoapi from their working branch because their releases pin specific
+# versions of each requirement, which are old and conflict with our dependencies
 dependencies = [
     "flask",
     "natcap.invest",
-    "pygeoapi>=0.23.2",
+    "pygeoapi @ git+https://github.com/geopython/pygeoapi.git",
     "google-cloud-storage"
 ]
 

--- a/invest_processes/pyproject.toml
+++ b/invest_processes/pyproject.toml
@@ -11,7 +11,7 @@ dynamic = ["version"] # the version is provided dynamically by setuptools_scm
 dependencies = [
     "flask",
     "natcap.invest",
-    "pygeoapi",
+    "pygeoapi>=0.23.2",
     "google-cloud-storage"
 ]
 

--- a/invest_processes/pyproject.toml
+++ b/invest_processes/pyproject.toml
@@ -12,6 +12,9 @@ dependencies = [
     "flask",
     "natcap.invest",
     "pygeoapi>=0.23.2",
+    # rasterio is not a direct dependency, but a dependency of pygeoapi.
+    # older versions need pkg_resources to install, which is deprecated in recent python versions
+    "rasterio>=1.4.0",
     "google-cloud-storage"
 ]
 
@@ -19,7 +22,7 @@ dependencies = [
 homepage = "http://github.com/natcap/invest-compute"
 
 [build-system]
-requires = ['setuptools>=64', 'wheel', 'setuptools_scm>=8.0']
+requires = ['setuptools>=64,<82', 'wheel', 'setuptools_scm>=8.0']
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/invest_processes/pyproject.toml
+++ b/invest_processes/pyproject.toml
@@ -8,7 +8,6 @@ maintainers = [
     {name = "Natural Capital Project Software Team"}
 ]
 dynamic = ["version"] # the version is provided dynamically by setuptools_scm
-
 dependencies = [
     "flask",
     "natcap.invest",

--- a/invest_processes/pyproject.toml
+++ b/invest_processes/pyproject.toml
@@ -19,9 +19,7 @@ dependencies = [
 homepage = "http://github.com/natcap/invest-compute"
 
 [build-system]
-# setuptools<82 because pkg_resources was deprecated, but we still need it for
-# rasterio as a dependency of pygeoapi
-requires = ['setuptools>=64,<81', 'wheel', 'setuptools_scm>=8.0']
+requires = ['setuptools>=64', 'wheel', 'setuptools_scm>=8.0']
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/invest_processes/pyproject.toml
+++ b/invest_processes/pyproject.toml
@@ -12,7 +12,7 @@ dynamic = ["version"] # the version is provided dynamically by setuptools_scm
 dependencies = [
     "flask",
     "natcap.invest",
-    "pygeoapi==0.23.0",
+    "pygeoapi==0.23.0",  # https://github.com/geopython/pygeoapi/issues/2321
     "google-cloud-storage"
 ]
 

--- a/invest_processes/pyproject.toml
+++ b/invest_processes/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
 homepage = "http://github.com/natcap/invest-compute"
 
 [build-system]
-requires = ['setuptools>=64,<82', 'wheel', 'setuptools_scm>=8.0']
+requires = ['setuptools>=64', 'wheel', 'setuptools_scm>=8.0']
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/slurm_cluster_config/server_interface.tf
+++ b/slurm_cluster_config/server_interface.tf
@@ -244,14 +244,15 @@ resource "google_api_gateway_gateway" "api_gw" {
 # -----------------------------------------------------------------------------
 # API Key
 #
-# The client must provide this key in their requests as a URL parameter
+# The client must provide an API key in their requests as a URL parameter
 # called "key". The API Gateway enforces that the key is provided correctly.
-# The key may be accessed by running `terraform output api_key` after a
+# The keys may be accessed by running `terraform output api_keys` after a
 # successful `terraform apply`.
-#
-# TODO: Generate separate keys for multiple users
 
 # Map API key names to display names
+# To create a new key for a new client, add them to this map.
+# This will not scale to many hundreds of clients, see
+# https://github.com/natcap/invest-compute/issues/34
 locals {
   api_clients = {
     primary = "Primary key - for software team use"

--- a/slurm_cluster_config/server_interface.tf
+++ b/slurm_cluster_config/server_interface.tf
@@ -299,8 +299,9 @@ resource "google_compute_url_map" "default" {
 
 # Define the domain name pointing to the Load Balancer as a variable
 variable "domain_name" {
-  description = "The load balancer domain name, e.g. 'compute.naturalcapitalalliance.org'"
+  description = "The load balancer domain name, e.g. compute.naturalcapitalalliance.org"
   type        = string
+  default     = "compute.naturalcapitalalliance.org"
 }
 
 # Create a Google-managed SSL certificate for the load balancer
@@ -384,8 +385,9 @@ resource "google_project_iam_member" "github_actions_uploader_binding" {
 
 # Define the GitHub Organization name as a variable
 variable "github_repo" {
-  description = "The GitHub repo name, for example 'natcap/invest-compute'"
+  description = "The GitHub repo name, e.g. natcap/invest-compute"
   type        = string
+  default     = "natcap/invest-compute"
 }
 
 # Create Workload Identity Pool and Provider to authenticate GHA workflows

--- a/slurm_cluster_config/server_interface.tf
+++ b/slurm_cluster_config/server_interface.tf
@@ -251,9 +251,19 @@ resource "google_api_gateway_gateway" "api_gw" {
 #
 # TODO: Generate separate keys for multiple users
 
-resource "google_apikeys_key" "primary_key" {
-  name         = "primary-key"
-  display_name = "My Primary API Key"
+# Map API key names to display names
+locals {
+  api_clients = {
+    primary = "Primary key - for software team use"
+    urban-online = "Urban Online client"
+  }
+}
+
+
+resource "google_apikeys_key" "api_keys" {
+  for_each     = local.api_clients
+  name         = each.key
+  display_name = each.value
   project      = var.project_id
 
   restrictions {
@@ -263,11 +273,10 @@ resource "google_apikeys_key" "primary_key" {
   }
 }
 
-output "api_key" {
-  value     = google_apikeys_key.primary_key.key_string
+output "api_keys" {
+  value     = {for key in google_apikeys_key.api_keys: key.name => key.key_string}
   sensitive = true
 }
-
 
 # ------------------------------------------------------------------------------
 # Load Balancer

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -77,28 +77,26 @@ class PyGeoAPIServerTests(unittest.TestCase):
         )
         self.assertEqual(response.status_code, 201)
         execution_response = json.loads(response.get_data(as_text=True))
-        # pygeoapi incorrectly calls this key 'id' instead of 'job_id'
-        # https://github.com/geopython/pygeoapi/issues/2197
-        self.assertEqual(set(execution_response.keys()), {'status', 'type', 'id'})
+        self.assertEqual(set(execution_response.keys()), {'status', 'type', 'jobID'})
         self.assertEqual(execution_response['status'], 'accepted')
         # according to the OGC standard this should always be 'process'
         self.assertEqual(execution_response['type'], 'process')
         self.assertEqual(
             response.headers['Location'],
-            f'http://localhost:5000/jobs/{execution_response["id"]}')
+            f'http://localhost:5000/jobs/{execution_response["jobID"]}')
 
         # poll status until the job finishes
         # TODO: test with a longer running job
         while True:
             job_response = json.loads(self.client.get(
-                f'/jobs/{execution_response["id"]}').get_data(as_text=True))
+                f'/jobs/{execution_response["jobID"]}').get_data(as_text=True))
             self.assertNotIn(job_response['status'], {'failed', 'dismissed'})
             if job_response['status'] == 'successful':
                 break
             time.sleep(5)
 
         results_response = json.loads(self.client.get(
-            f'/jobs/{execution_response["id"]}/results?f=json').get_data(
+            f'/jobs/{execution_response["jobID"]}/results?f=json').get_data(
             as_text=True))
         local_dest_path = os.path.join(self.workspace_dir, 'results')
         os.mkdir(local_dest_path)
@@ -127,27 +125,25 @@ class PyGeoAPIServerTests(unittest.TestCase):
         )
         self.assertEqual(response.status_code, 201)
         execution_response = json.loads(response.get_data(as_text=True))
-        # pygeoapi incorrectly calls this key 'id' instead of 'job_id'
-        # https://github.com/geopython/pygeoapi/issues/2197
-        self.assertEqual(set(execution_response.keys()), {'status', 'type', 'id'})
+        self.assertEqual(set(execution_response.keys()), {'status', 'type', 'jobID'})
         self.assertEqual(execution_response['status'], 'accepted')
         # according to the OGC standard this should always be 'process'
         self.assertEqual(execution_response['type'], 'process')
         self.assertEqual(
             response.headers['Location'],
-            f'http://localhost:5000/jobs/{execution_response["id"]}')
+            f'http://localhost:5000/jobs/{execution_response["jobID"]}')
 
         # poll status until the job finishes
         # TODO: test with a longer running job
         while True:
             job_response = json.loads(self.client.get(
-                f'/jobs/{execution_response["id"]}').get_data(as_text=True))
+                f'/jobs/{execution_response["jobID"]}').get_data(as_text=True))
             if job_response['status'] in {'successful', 'failed', 'dismissed'}:
                 break
             time.sleep(5)
 
         results_response = json.loads(self.client.get(
-            f'/jobs/{execution_response["id"]}/results?f=json').get_data(
+            f'/jobs/{execution_response["jobID"]}/results?f=json').get_data(
             as_text=True))
 
         local_dest_path = os.path.join(self.workspace_dir, 'results')


### PR DESCRIPTION
Fixes #16 

Manage multiple clients with a simple map of API keys. See #16 for details, this is not a hugely scalable solution but should be fine for the time being.

I anticipate working on integrating Urban Online with the compute API soon, so I added that to the client map. 

Also set default values for the input variables so I don't have to keep entering them every time.

A recent release of pygeoapi fixed an issue in their response keys, so I've updated the tests accordingly.